### PR TITLE
Migrate REP token contract address from v1 to v2

### DIFF
--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -152,7 +152,7 @@ const equivalentSets = [
     ],
     [
         [
-            '0x1985365e9f78359a9B6AD760e32412f4a445E862', // REP
+            '0x221657776846890989a759ba2973e427dff5c9bb', // REPv2
             '0x71010A9D003445aC60C4e6A7017c1E89A477B438', // aREP
             '0x158079Ee67Fce2f58472A96584A73C7Ab9AC95c1', // cREP
             '0xBd56E9477Fc6997609Cf45F84795eFbDAC642Ff1', // iREP


### PR DESCRIPTION
REPv1 is no longer eligible for liquidity mining, but REPv2 is, so this commit updates the equivalency set to include REPv2 as a hard peg to aREP, cREP, etc.