### PR TITLE
Add logic for new variable caps

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ async function getRewardsAtBlock(i, pools, prices, capTiers, poolProgress) {
         let poolMarketCap = bnum(0);
         let originalPoolMarketCapFactor = bnum(0);
         let eligibleTotalWeight = bnum(0);
+        let poolCapTiers = [];
         let poolRatios = [];
 
         for (const t of currentTokens) {
@@ -148,6 +149,7 @@ async function getRewardsAtBlock(i, pools, prices, capTiers, poolProgress) {
                 ];
             }
 
+            poolCapTiers.push(capTiers[t]);
             poolRatios.push(utils.scale(normWeight, -18));
             poolMarketCap = poolMarketCap.plus(tokenMarketCap);
         }
@@ -155,7 +157,7 @@ async function getRewardsAtBlock(i, pools, prices, capTiers, poolProgress) {
         poolData.marketCap = poolMarketCap;
         poolData.eligibleTotalWeight = eligibleTotalWeight;
 
-        let ratioFactor = getRatioFactor(currentTokens, poolRatios);
+        let ratioFactor = getRatioFactor(currentTokens, poolRatios, poolCapTiers);
         let wrapFactor = getWrapFactor(currentTokens, poolRatios);
 
         let poolFee = await bPool.methods.getSwapFee().call(undefined, i);

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ async function getRewardsAtBlock(i, pools, prices, capTiers, poolProgress) {
 
         let poolFee = await bPool.methods.getSwapFee().call(undefined, i);
         poolFee = utils.scale(poolFee, -16); // -16 = -18 * 100 since it's in percentage terms
-        let feeFactor = bnum(getFeeFactor(poolFee));
+        let feeFactor = getFeeFactor(poolFee);
 
         originalPoolMarketCapFactor = feeFactor
             .times(ratioFactor)

--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ async function getRewardsAtBlock(i, pools, prices, capTiers, poolProgress) {
         let eligibleTotalWeight = bnum(0);
         let poolCapTiers = [];
         let poolRatios = [];
+        let poolTokens = [];
 
         for (const t of currentTokens) {
             // Skip token if it doesn't have a price
@@ -149,16 +150,17 @@ async function getRewardsAtBlock(i, pools, prices, capTiers, poolProgress) {
                 ];
             }
 
-            poolCapTiers.push(capTiers[t]);
+            poolCapTiers.push(capTiers[token]);
             poolRatios.push(utils.scale(normWeight, -18));
+            poolTokens.push(token);
             poolMarketCap = poolMarketCap.plus(tokenMarketCap);
         }
 
         poolData.marketCap = poolMarketCap;
         poolData.eligibleTotalWeight = eligibleTotalWeight;
 
-        let ratioFactor = getRatioFactor(currentTokens, poolRatios, poolCapTiers);
-        let wrapFactor = getWrapFactor(currentTokens, poolRatios);
+        let ratioFactor = getRatioFactor(poolTokens, poolRatios, poolCapTiers);
+        let wrapFactor = getWrapFactor(poolTokens, poolRatios);
 
         let poolFee = await bPool.methods.getSwapFee().call(undefined, i);
         poolFee = utils.scale(poolFee, -16); // -16 = -18 * 100 since it's in percentage terms

--- a/lib/factors.js
+++ b/lib/factors.js
@@ -1,14 +1,13 @@
-const { BAL_TOKEN, uncappedTokens, equivalentSets } = require('./tokens');
+const { BAL_TOKEN, equivalentSets } = require('./tokens');
 const BigNumber = require('bignumber.js');
 
-const CAP_TIERS = [
-    0,
-    1000000,
-    3000000,
-    10000000,
-    30000000,
-    100000000,
-];
+const CAP_TIERS = {
+    'cap1': bnum(1000000),
+    'cap2': bnum(3000000),
+    'cap3': bnum(10000000),
+    'cap4': bnum(30000000),
+    'cap5': bnum(100000000),
+};
 
 const WRAP_FACTOR_HARD = 0.1;
 const WRAP_FACTOR_SOFT = 0.2;
@@ -24,28 +23,26 @@ function bnum(val) {
 }
 
 function getCapFactor(token, marketCap, capTier) {
-    let cap = CAP_TIERS[capTier];
-    if (
-        !uncappedTokens.includes(token) &&
-        bnum(marketCap).isGreaterThan(bnum(cap))
-    ) {
-        return bnum(cap).div(marketCap);
-    } else {
-        return bnum(1);
+    if (capTier in CAP_TIERS) {
+        let cap = CAP_TIERS[capTier];
+        if (bnum(marketCap).isGreaterThan(cap)) {
+            return cap.div(marketCap);
+        }
     }
+    return bnum(1);
 }
 
 function getFeeFactor(feePercentage) {
     return Math.exp(-Math.pow(feePercentage * 0.25, 2));
 }
 
-function getBalFactor(balMultiplier, token1, weight1, token2, weight2) {
-    if (token1 == BAL_TOKEN && uncappedTokens.includes(token2)) {
+function getBalFactor(balMultiplier, token1, weight1, capTier1, token2, weight2, capTier2) {
+    if (token1 == BAL_TOKEN && !(capTier2 in CAP_TIERS)) {
         return balMultiplier
             .times(weight1)
             .plus(weight2)
             .div(weight1.plus(weight2));
-    } else if (token2 == BAL_TOKEN && uncappedTokens.includes(token1)) {
+    } else if (token2 == BAL_TOKEN && !(capTier1 in CAP_TIERS)) {
         return weight1
             .plus(balMultiplier.times(weight2))
             .div(weight1.plus(weight2));
@@ -54,7 +51,7 @@ function getBalFactor(balMultiplier, token1, weight1, token2, weight2) {
     }
 }
 
-function getRatioFactor(tokens, weights) {
+function getRatioFactor(tokens, weights, capTiers) {
     let ratioFactorSum = bnum(0);
     let pairWeightSum = bnum(0);
     let balMultiplier = bnum(2);
@@ -73,8 +70,10 @@ function getRatioFactor(tokens, weights) {
                     balMultiplier,
                     tokens[j],
                     weights[j],
+                    capTiers[j],
                     tokens[k],
-                    weights[k]
+                    weights[k],
+                    capTiers[k]
                 );
 
                 ratioFactorSum = ratioFactorSum.plus(

--- a/lib/factors.js
+++ b/lib/factors.js
@@ -1,17 +1,6 @@
 const { BAL_TOKEN, equivalentSets } = require('./tokens');
 const BigNumber = require('bignumber.js');
 
-const CAP_TIERS = {
-    'cap1': bnum(1000000),
-    'cap2': bnum(3000000),
-    'cap3': bnum(10000000),
-    'cap4': bnum(30000000),
-    'cap5': bnum(100000000),
-};
-
-const WRAP_FACTOR_HARD = 0.1;
-const WRAP_FACTOR_SOFT = 0.2;
-
 BigNumber.config({
     EXPONENTIAL_AT: [-100, 100],
     ROUNDING_MODE: BigNumber.ROUND_DOWN,
@@ -21,6 +10,17 @@ BigNumber.config({
 function bnum(val) {
     return new BigNumber(val.toString());
 }
+
+const CAP_TIERS = {
+    'cap1': bnum(1000000),
+    'cap2': bnum(3000000),
+    'cap3': bnum(10000000),
+    'cap4': bnum(30000000),
+    'cap5': bnum(100000000),
+};
+
+const WRAP_FACTOR_HARD = bnum(0.1);
+const WRAP_FACTOR_SOFT = bnum(0.2);
 
 function getCapFactor(token, marketCap, capTier) {
     if (capTier in CAP_TIERS) {
@@ -33,7 +33,7 @@ function getCapFactor(token, marketCap, capTier) {
 }
 
 function getFeeFactor(feePercentage) {
-    return Math.exp(-Math.pow(feePercentage * 0.25, 2));
+    return bnum(Math.exp(-Math.pow(feePercentage * 0.25, 2)));
 }
 
 function getBalFactor(balMultiplier, token1, weight1, capTier1, token2, weight2, capTier2) {
@@ -117,7 +117,7 @@ function getWrapFactorForPair(tokenA, tokenB) {
             break;
         }
     }
-    return 1.0;
+    return bnum(1);
 }
 
 function getWrapFactor(tokens, weights) {
@@ -131,7 +131,7 @@ function getWrapFactor(tokens, weights) {
                 let pairWeight = weights[x].times(weights[y]);
                 let wrapFactorPair = getWrapFactorForPair(tokens[x], tokens[y]);
                 wrapFactorSum = wrapFactorSum.plus(
-                    bnum(wrapFactorPair).times(pairWeight)
+                    wrapFactorPair.times(pairWeight)
                 );
                 pairWeightSum = pairWeightSum.plus(pairWeight);
             }

--- a/lib/factors.js
+++ b/lib/factors.js
@@ -19,6 +19,8 @@ const CAP_TIERS = {
     'cap5': bnum(100000000),
 };
 
+const FEE_FACTOR_MULT = 0.25;
+
 const WRAP_FACTOR_HARD = bnum(0.1);
 const WRAP_FACTOR_SOFT = bnum(0.2);
 
@@ -33,7 +35,7 @@ function getCapFactor(token, marketCap, capTier) {
 }
 
 function getFeeFactor(feePercentage) {
-    return bnum(Math.exp(-Math.pow(feePercentage * 0.25, 2)));
+    return bnum(Math.exp(-Math.pow(feePercentage * FEE_FACTOR_MULT, 2)));
 }
 
 function getBalFactor(balMultiplier, token1, weight1, capTier1, token2, weight2, capTier2) {

--- a/lib/factors.js
+++ b/lib/factors.js
@@ -1,6 +1,15 @@
 const { BAL_TOKEN, uncappedTokens, equivalentSets } = require('./tokens');
 const BigNumber = require('bignumber.js');
 
+const CAP_TIERS = [
+    0,
+    1000000,
+    3000000,
+    10000000,
+    30000000,
+    100000000,
+];
+
 const WRAP_FACTOR_HARD = 0.1;
 const WRAP_FACTOR_SOFT = 0.2;
 
@@ -12,6 +21,18 @@ BigNumber.config({
 
 function bnum(val) {
     return new BigNumber(val.toString());
+}
+
+function getCapFactor(token, marketCap, capTier) {
+    let cap = CAP_TIERS[capTier];
+    if (
+        !uncappedTokens.includes(token) &&
+        bnum(marketCap).isGreaterThan(bnum(cap))
+    ) {
+        return bnum(cap).div(marketCap);
+    } else {
+        return bnum(1);
+    }
 }
 
 function getFeeFactor(feePercentage) {
@@ -123,4 +144,4 @@ function getWrapFactor(tokens, weights) {
     return wrapFactor;
 }
 
-module.exports = { getFeeFactor, getBalFactor, getRatioFactor, getWrapFactor };
+module.exports = { getCapFactor, getFeeFactor, getBalFactor, getRatioFactor, getWrapFactor };

--- a/lib/factors.js
+++ b/lib/factors.js
@@ -19,7 +19,7 @@ const CAP_TIERS = {
     'cap5': bnum(100000000),
 };
 
-const FEE_FACTOR_MULT = 0.25;
+const FEE_FACTOR_K = 0.25;
 
 const WRAP_FACTOR_HARD = bnum(0.1);
 const WRAP_FACTOR_SOFT = bnum(0.2);
@@ -35,7 +35,7 @@ function getCapFactor(token, marketCap, capTier) {
 }
 
 function getFeeFactor(feePercentage) {
-    return bnum(Math.exp(-Math.pow(feePercentage * FEE_FACTOR_MULT, 2)));
+    return bnum(Math.exp(-Math.pow(feePercentage * FEE_FACTOR_K, 2)));
 }
 
 function getBalFactor(balMultiplier, token1, weight1, capTier1, token2, weight2, capTier2) {

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,13 +1,5 @@
 const BAL_TOKEN = '0xba100000625a3754423978a60c9317c58a424e3D';
 
-const uncappedTokens = [
-    '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-    '0x6B175474E89094C44Da98b954EedeAC495271d0F', // DAI
-    '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
-    '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', // WBTC
-    '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
-];
-
 const equivalentSets = [
     [
         [
@@ -176,6 +168,5 @@ const equivalentSets = [
 
 module.exports = {
     BAL_TOKEN,
-    uncappedTokens,
     equivalentSets,
 };


### PR DESCRIPTION
The cap for capFactor is no longer fixed at $10M, but variable for each token among a set of fixed tiers: https://forum.balancer.finance/t/proposal-to-update-the-whitelist-process/217

This PR accomplishes the following:
- Query cap tiers for each token from the whitelist defined in assets/lists/eligible.json.
- Define a getCapFactor() computation and replace the fixed $10M logic.
- Remove the uncappedTokens list, keeping all cap configuration (except dollar values) within the assets repository.
- Fix a small bug in the balFactor and wrapFactor computation for the case where an eligible pool contains some ineligible tokens.

This PR depends on another in the assets repository: https://github.com/balancer-labs/assets/pull/13