### PR TITLE
BAL Whitelist - Round 10

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -73,6 +73,7 @@ export const equivalentSets = [
         ],
         [
             '0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8', // yCRV
+            '0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c', // yyCRV
         ],
         [
             '0x8E870D67F660D95d5be530380D0eC0bd388289E1', // PAX

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -69,6 +69,9 @@ export const equivalentSets = [
             '0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5', // yUSD-SEP20
         ],
         [
+            '0xB2FdD60AD80ca7bA89B9BAb3b5336c2601C020b4', // yUSD-OCT20
+        ],
+        [
             '0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8', // yCRV
         ],
         [


### PR DESCRIPTION
Add equivalentSets introduced by proposal: https://forum.balancer.finance/t/bal-whitelist-round-10/333
- yUSD-OCT20 is a USD (soft) peg.
- yyCRV is a wrapper (hard peg) on yCRV, which in turn is a USD (soft) peg.

These changes were effective August 31 and must be included in the Week 14 calculation.