### PR TITLE
Merkle proofs manual

### DIFF
--- a/js/src/getMerkleRoots.ts
+++ b/js/src/getMerkleRoots.ts
@@ -1,4 +1,5 @@
 import { loadTree } from './merkle';
+import { toWei, soliditySha3 } from 'web3-utils';
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
@@ -21,4 +22,11 @@ reports.forEach(([week, report]) => {
     const merkleTree = loadTree(report);
     console.log(`Week ${week}`);
     console.log(merkleTree.getHexRoot());
+
+    const address = process.env.ADDRESS;
+    if (address && address in report) {
+        const balance = toWei(report[address]);
+        const leaf = soliditySha3(address, balance);
+        console.log(`Proof ${merkleTree.getHexProof(leaf)}`);
+    }
 });

--- a/js/src/getMerkleRoots.ts
+++ b/js/src/getMerkleRoots.ts
@@ -20,13 +20,14 @@ console.log('Merkle roots');
 
 reports.forEach(([week, report]) => {
     const merkleTree = loadTree(report);
-    console.log(`Week ${week}`);
-    console.log(merkleTree.getHexRoot());
 
     const address = process.env.ADDRESS;
     if (address && address in report) {
         const balance = toWei(report[address]);
         const leaf = soliditySha3(address, balance);
-        console.log(`Proof ${merkleTree.getHexProof(leaf)}`);
+        console.log(`Week: ${week - 20}`);
+        console.log(`> Balance: ${balance}`);
+        console.log(`> Root: ${merkleTree.getHexRoot()}`);
+        console.log(`> Proof: ${merkleTree.getHexProof(leaf)}`);
     }
 });


### PR DESCRIPTION
Allows you to set an `ADDRESS` env var to compute merkle proofs as part of the merkle root calculation

I found this helpful in helping a user manually claim