### PR TITLE
Remove tests from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,3 @@ workflows:
     build_test:
         jobs:
             - build
-            - test:
-                  requires:
-                      - build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "build": "babel ./js/src --out-dir js/lib --extensions '.ts,.tsx'",
         "timestamps": "node js/timestamps.js",
-        "test": "mocha --require babel-polyfill test/*",
+        "test": "mocha --require babel-polyfill js/test/*",
         "ipfs-publish": "node js/publish.js",
         "merkle-roots": "node js/lib/getMerkleRoots.js"
     },


### PR DESCRIPTION
tests are not relevant to the current state of the code - remove them

Would like to move tests to github actions for consistency once we put in the time to test the current code