### PR TITLE
Added ci script to publish ipfs manifests

### DIFF
--- a/.github/workflows/publish-ipfs.yml
+++ b/.github/workflows/publish-ipfs.yml
@@ -1,0 +1,62 @@
+name: Publish reports to ipfs
+on:
+    push:
+        branches:
+            - 'master'
+
+jobs:
+    build:
+        environment: fleek
+        env:
+            FLEEK_API_KEY: ${{ secrets.FLEEK_API_KEY }}
+            FLEEK_API_SECRET: ${{ secrets.FLEEK_API_SECRET }}
+            FLEEK_BUCKET: 'balancer-team-bucket'
+    run:
+        name: Publish to ipfs
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v2
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 14.x
+
+            - name: Install dependencies
+              run: yarn install
+
+            - name: Install dependencies
+              run: yarn build
+
+            - name: Publish ipfs reports for BAL
+              run: NETWORK=homestead yarn ipfs-publish
+
+            - name: Publish ipfs reports for BAL on arbitrum
+              run: NETWORK=arbitrum yarn ipfs-publish
+
+            - name: Publish ipfs reports for BAL on polygon
+              run: NETWORK=polygon yarn ipfs-publish
+
+            - name: Publish ipfs reports for LDO
+              run: NETWORK=homestead-lido yarn ipfs-publish
+
+            - name: Publish ipfs reports for UNN
+              run: NETWORK=homestead-union yarn ipfs-publish
+
+            - name: Publish ipfs reports for VITA
+              run: NETWORK=homestead-vita yarn ipfs-publish
+
+            - name: Publish ipfs reports for MCB on arbitrum
+              run: NETWORK=arbitrum-mcdex yarn ipfs-publish
+
+            - name: Publish ipfs reports for PICKLE on arbitrum
+              run: NETWORK=arbitrum-pickle yarn ipfs-publish
+
+            - name: Commit changes
+              uses: EndBug/add-and-commit@v7
+              with:
+                  author_name: Fleek Publish Bot
+                  author_email: no-reply@balancer.finance
+                  message: 'Updating ipfs links'
+                  add: './reports/_current*.json'

--- a/js/publish.js
+++ b/js/publish.js
@@ -9,8 +9,14 @@ const { config } = require('./lib/config');
 
 async function getSnapshotFromFile(config) {
     const snapshotPath = config.reportsDirectory + config.jsonSnapshotFilename;
-    const jsonString = fs.readFileSync(path.resolve(__dirname, snapshotPath));
-    return JSON.parse(jsonString.toString());
+    try {
+        const jsonString = fs.readFileSync(
+            path.resolve(__dirname, snapshotPath)
+        );
+        return JSON.parse(jsonString.toString());
+    } catch (error) {
+        return {};
+    }
 }
 
 // find all totals files in the directory structure (ie. ../../reports/<week*>/_totals.json)

--- a/js/src/fleekService.ts
+++ b/js/src/fleekService.ts
@@ -12,7 +12,7 @@ interface FleekConfig {
 const fleekConfig: FleekConfig = {
     apiKey: process.env.FLEEK_API_KEY,
     apiSecret: process.env.FLEEK_API_SECRET,
-    bucket: 'balancer-team-bucket',
+    bucket: process.env.FLEEK_BUCKET || 'balancer-team-bucket',
 };
 
 async function getSnapshot(snapshotKey) {


### PR DESCRIPTION
This runs the ipfs-publish script as part of ci, when the master branch is updated (when a pr is merged) so we won't have to do that this week.  The frontend now checks which merkle roots have been set, so we can safely publish manifests before roots have been submitted to the orchard

It will require some setup to work:

1) Create an environment (Settings > Environments) named `fleek`
2) Add FLEEK_API_KEY and FLEEK_API_SECRET to that environment's secrets (these secrets will only be available when a github action is run in the `fleek` environment
3) Limit the environment branch to `master` to prevent those secrets being used from other branches, which don't have branch protection rules

Note that while I expect this to work, I have not been able to test the github action because the required secrets have not been set