### PR TITLE
Added script to generate migration tree

### DIFF
--- a/js/src/migrateChannel.ts
+++ b/js/src/migrateChannel.ts
@@ -1,0 +1,23 @@
+import { loadTree } from './merkle';
+import { soliditySha3 } from 'web3-utils';
+const { argv } = require('yargs');
+const { scale } = require('./utils');
+
+const { recipient, decimals, balance } = argv;
+
+const report = {};
+report[recipient] = balance;
+
+const merkleTree = loadTree(report, decimals || 18);
+const root = merkleTree.getHexRoot();
+
+const scaledBalance = scale(balance, decimals || 18);
+const leaf = soliditySha3(recipient, scaledBalance);
+
+console.log(`Migration tree to transfer tokens to ${recipient}`);
+console.log('> Inputs:', { recipient, decimals, balance });
+console.log(`> Scaled Balance: ${scaledBalance}`);
+console.log(`> Root (same as leaf): ${merkleTree.getHexRoot()}`);
+console.log(
+    `> Proof is empty []?: ${merkleTree.getHexProof(leaf).length == 0}`
+);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "timestamps": "node js/timestamps.js",
         "test": "mocha --require babel-polyfill js/test/*",
         "ipfs-publish": "node js/publish.js",
-        "merkle-roots": "node js/lib/getMerkleRoots.js"
+        "merkle-roots": "node js/lib/getMerkleRoots.js",
+        "migrateChannel": "node js/lib/migrateChannel.js"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
To reclaim NOTE tokens:

```
$ node js/lib/migrateChannel.js --recipient 0xF1C2dD9bD863f2444086B739383F1043E6b88F69 --balance 30000 --decimals 8
Migration tree to transfer tokens to 0xF1C2dD9bD863f2444086B739383F1043E6b88F69
> Inputs: {
  recipient: '0xF1C2dD9bD863f2444086B739383F1043E6b88F69',
  decimals: 8,
  balance: 30000
}
> Scaled Balance: 3000000000000
> Root (same as leaf): 0x4445ac3fd6b5cfd5b8c70855598d6f1b9ae805493e3e0fccb3ab8d98122bd6a5
> Proof is empty []?: true
```