### PR TITLE
Exclude THX team from distributions

### DIFF
--- a/src/liquidity_mining_V2.sql
+++ b/src/liquidity_mining_V2.sql
@@ -36,6 +36,7 @@ BPT_SUPPLY AS (
   WHERE token_address IN UNNEST(pool_addresses)
   AND address <> '0x0000000000000000000000000000000000000000'
   AND address <> '0xba12222222228d8ba445958a75a0704d566bf2c8'
+  AND address <> '0x59429282a4e566373a1f2d5f20cf08184b46ee07'
   AND balance > 0
   GROUP BY block_number, token_address
 ),
@@ -48,6 +49,7 @@ LPS_SHARES AS (
   WHERE a.token_address IN UNNEST(pool_addresses)
   AND address <> '0x0000000000000000000000000000000000000000'
   AND address <> '0xba12222222228d8ba445958a75a0704d566bf2c8'
+  AND address <> '0x59429282a4e566373a1f2d5f20cf08184b46ee07'
   AND balance > 0
 ),
 SHARES_INTEGRATOR AS (


### PR DESCRIPTION
The THX team bootstrapped liquiity in the 80/20 THX/USDC pool (`0xb204bf10bc3a5435017d3db247f56da601dfe08a`) and would like to remove itself (`0x59429282A4e566373a1F2D5F20CF08184b46ee07`) from the list of addresses eligible to receive liquidity mining incentives, as per conversations with Baller Mike B.

This PR removes their address from any distributions in the program, which they have agreed to.

We've never done this before, but for similar requests (ie redirects) we normally require a signed message or some other proof of ownership. This address being a Gnosis Safe on Polygon has made it difficult. As an alternative, we suggest the team transfers 0.00001234 MATIC to itself (ie from `0x59429282A4e566373a1F2D5F20CF08184b46ee07` to `0x59429282A4e566373a1F2D5F20CF08184b46ee07`) as a proof of ownership/intent.